### PR TITLE
Add new backend to prod and stag

### DIFF
--- a/tf/production/main.tf
+++ b/tf/production/main.tf
@@ -31,5 +31,19 @@ resource "fastly_service_v1" "api-service-production-0p7ElaomsexoNHwdMbYJac" {
     name                  = "localhost"
     port                  = 80
   }
+
+  backend {
+    auto_loadbalance      = true
+    between_bytes_timeout = 10000
+    connect_timeout       = 1000
+    error_threshold       = 0
+    first_byte_timeout    = 15000
+    max_conn              = 200
+    ssl_check_cert        = true
+    use_ssl               = false
+    weight                = 100
+    name                  = "localhost-2"
+    port                  = 80
+  }
 }
 

--- a/tf/staging/main.tf
+++ b/tf/staging/main.tf
@@ -31,5 +31,20 @@ resource "fastly_service_v1" "api-service-staging-1SOF2sf218IFdLZhnqBlKB" {
     name                  = "localhost"
     port                  = 80
   }
+
+  backend {
+address               = "1.2.3.4"
+auto_loadbalance      = true
+between_bytes_timeout = 10000
+connect_timeout       = 1000
+error_threshold       = 0
+first_byte_timeout    = 15000
+max_conn              = 200
+ssl_check_cert        = true
+use_ssl               = false
+weight                = 100
+name                  = "localhost-2"
+port                  = 80
+  }
 }
 


### PR DESCRIPTION
This PR adds a new backend definition to the `staging` and to the `production` environment.

Notes for Patrick:

* In `staging` I didn't format `main.tf` properly --> **terraform fmt Failed**
* In `production` I didn't specify a required field in `main.tf` --> **terraform validate Failed**